### PR TITLE
Redefined as class attributes to fix TypeError when importing UniDepthV1HF

### DIFF
--- a/unidepth/models/unidepthv1/unidepthv1.py
+++ b/unidepth/models/unidepthv1/unidepthv1.py
@@ -349,10 +349,12 @@ class UniDepthV1(nn.Module):
         )
 
 
-class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin,
-                   library_name="UniDepth",
-                   repo_url="https://github.com/lpiccinelli-eth/UniDepth",
-                   tags=["monocular-metric-depth-estimation"]):
+class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin):
+    
+    library_name="UniDepth"
+    repo_url="https://github.com/lpiccinelli-eth/UniDepth"
+    tags=["monocular-metric-depth-estimation"]
+
     def __init__(self, config):
         mod = importlib.import_module("unidepth.models.encoder")
         pixel_encoder_factory = getattr(mod, config["model"]["pixel_encoder"]["name"])


### PR DESCRIPTION
When following the usage directions provided [here](https://huggingface.co/nielsr/unidepth-v1-convnext-large), the following typerror occurs when importing the UniDepthV1HF class.

```bash

Python 3.10.14 (main, Mar 25 2024, 21:45:25) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from unidepth.models import UniDepthV1HF
Triton is not available, some optimizations will not be enabled.
This is just a warning: triton is not available
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/UniDepth/unidepth/models/__init__.py", line 1, in <module>
    from .unidepthv1 import UniDepthV1, UniDepthV1HF
  File "/UniDepth/unidepth/models/unidepthv1/__init__.py", line 1, in <module>
    from .unidepthv1 import UniDepthV1, UniDepthV1HF
  File "/UniDepth/unidepth/models/unidepthv1/unidepthv1.py", line 352, in <module>
    class UniDepthV1HF(UniDepthV1, PyTorchModelHubMixin,
TypeError: UniDepthV1HF.__init_subclass__() takes no keyword arguments

```

Fix: Defined the keyword arguments as class attributes and now it works. I am not sure whether this is the intended solution.
